### PR TITLE
docs(ui): update 3.4 Modules & Services v2 documentation

### DIFF
--- a/www/apps/book/app/basics/modules-and-services/page.mdx
+++ b/www/apps/book/app/basics/modules-and-services/page.mdx
@@ -30,7 +30,7 @@ For example, create the directory `src/modules/hello`.
 
 ### 1. Create Main Service
 
-A module must define a service. A service is a TypeScript or JavaScript class holding methods related to a business logic or commerce functionality.
+A module must define a service. A service is a TypeScript or JavaScript class holding methods related to a business logic or commerce functionality. It must be defined at the root of your module directory under `service.ts` filename
 
 For example, create the file `src/modules/hello/service.ts` with the following content:
 


### PR DESCRIPTION
## What

Explicitly define the requirement for module to work.

Service Class must be created under the `service.ts` file at the root of the module.

## Reference
https://docs.medusajs.com/v2/basics/modules-directory-structure#servicets
> A module must have a main service. It's created in the service.ts file at the root of your module directory as explained in a [previous chapter](https://docs.medusajs.com/v2/basics/modules-and-services).

It is mentioned in `3.6 Modules and Directory structure` that is must be explicitly named `service.ts` at the root directory of the module. But in the actual page (`3.4 Modules and Services`), it wasn't mentioned. 

## Changes
- explicitly mentioned and reference the `service.ts` requirement of `3.6 Modules and Directory structure` in `3.4 Modules and Services`

Avoid confusion.

